### PR TITLE
Use CompositionLocalProvider to simplify platform context usage

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/waqas028/data_store_kmp/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/org/waqas028/data_store_kmp/MainActivity.kt
@@ -1,5 +1,6 @@
 package org.waqas028.data_store_kmp
 
+import LocalPlatformContext
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
 import android.content.Context
@@ -7,6 +8,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import java.util.Calendar
@@ -17,7 +19,14 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
-            App(this)
+
+            val activityContext = LocalContext.current // This IS an Activity Context!
+
+
+            CompositionLocalProvider(LocalPlatformContext provides activityContext) {
+                App()
+            }
+
         }
     }
 }
@@ -25,8 +34,7 @@ class MainActivity : ComponentActivity() {
 @Preview
 @Composable
 fun AppAndroidPreview() {
-    val context = LocalContext.current
-    App(context)
+    App()
 }
 
 // Android-specific implementation

--- a/composeApp/src/commonMain/kotlin/org/waqas028/data_store_kmp/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/waqas028/data_store_kmp/App.kt
@@ -1,5 +1,6 @@
 package org.waqas028.data_store_kmp
 
+import LocalPlatformContext
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -20,15 +21,20 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 @Preview
-fun App(context: Any?) {
+fun App() {
     MaterialTheme {
-        AppContent(context)
+        AppContent()
     }
 }
 
 // commonMain
 @Composable
-fun AppContent(context: Any?) {
+fun AppContent() {
+
+
+    val platformContext = LocalPlatformContext.current
+
+
     var selectedDate by remember { mutableStateOf("Select a date") }
     var selectedTime by remember { mutableStateOf("Select a time") }
 
@@ -47,13 +53,13 @@ fun AppContent(context: Any?) {
 
         // Date Picker
         Text(text = "Date: $selectedDate")
-        Button(onClick = { pickDate(context) { date -> selectedDate = date } }) {
+        Button(onClick = { pickDate(platformContext) { date -> selectedDate = date } }) {
             Text("Pick a Date")
         }
 
         // Time Picker
         Text(text = "Time: $selectedTime")
-        Button(onClick = { pickTime(context) { time -> selectedTime = time } }) {
+        Button(onClick = { pickTime(platformContext) { time -> selectedTime = time } }) {
             Text("Pick a Time")
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/waqas028/data_store_kmp/PlatformContextCompositionLocal.kt
+++ b/composeApp/src/commonMain/kotlin/org/waqas028/data_store_kmp/PlatformContextCompositionLocal.kt
@@ -1,0 +1,4 @@
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+
+val LocalPlatformContext: ProvidableCompositionLocal<Any?> = compositionLocalOf { null }

--- a/composeApp/src/iosMain/kotlin/org/waqas028/data_store_kmp/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/org/waqas028/data_store_kmp/MainViewController.kt
@@ -1,5 +1,11 @@
 package org.waqas028.data_store_kmp
 
+import LocalPlatformContext
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.window.ComposeUIViewController
 
-fun MainViewController() = ComposeUIViewController { App(null) }
+fun MainViewController() = ComposeUIViewController {
+    CompositionLocalProvider(LocalPlatformContext provides null) {
+        App()
+    }
+}


### PR DESCRIPTION
 🧩 What’s Changed

- Added `CompositionLocalProvider(LocalPlatformContext provides context)` at the root
- Removed need to pass `activityContext` manually through every Composable
- Allows any Composable to use `LocalPlatformContext.current` when needed

 ✅ Benefits

- Reduces boilerplate
- Better developer experience using the DatePicker in KMP


Let me know if you’d like any improvements. Thanks!